### PR TITLE
Adding PWM Driver Module and Testbench to Motherboard Framework

### DIFF
--- a/sim/Peripherals/Test_PWMDriver.v
+++ b/sim/Peripherals/Test_PWMDriver.v
@@ -1,0 +1,121 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: SJSU
+// Engineer: Colin Schardt
+// 
+// Create Date: 07/16/2018 06:07:47 PM
+// Design Name: 
+// Module Name: PWM_Driver_tb
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module Test_PWMDriver;
+    
+    parameter MAX_CYCLE = 'd1_000_000;
+
+    reg clk_tb, rst_tb, load_tb;
+    reg [7:0] duty0_tb, duty1_tb, duty2_tb, duty3_tb, duty4_tb;
+    reg [7:0] period0_tb, period1_tb, period2_tb, period3_tb, period4_tb;
+    wire signal0_tb, signal1_tb, signal2_tb, signal3_tb, signal4_tb, signal5_tb, signal6_tb, signal7_tb, signal8_tb, signal9_tb;
+    wire signalA_tb, signalB_tb, signalC_tb, signalD_tb, signalE_tb, signalF_tb, signal10_tb, signal11_tb, signal12_tb; 
+    wire signal13_tb, signal14_tb, signal15_tb, signal16_tb, signal17_tb, signal18_tb;
+    
+    PWM_Driver DUT0( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty0_tb, period0_tb}), .signal(signal0_tb));
+    
+    PWM_Driver DUT1( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty1_tb, period0_tb}), .signal(signal1_tb));
+    
+    PWM_Driver DUT2( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty2_tb, period0_tb}), .signal(signal2_tb));
+    
+    PWM_Driver DUT3( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty3_tb, period0_tb}), .signal(signal3_tb));
+    
+    PWM_Driver DUT4( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty4_tb, period0_tb}), .signal(signal4_tb));
+    
+    PWM_Driver DUT5( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty0_tb, period1_tb}), .signal(signal5_tb));
+    
+    PWM_Driver DUT6( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty1_tb, period1_tb}), .signal(signal6_tb));
+    
+    PWM_Driver DUT7( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty2_tb, period1_tb}), .signal(signal7_tb));
+    
+    PWM_Driver DUT8( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty3_tb, period1_tb}), .signal(signal8_tb));
+    
+    PWM_Driver DUT9( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty4_tb, period1_tb}), .signal(signal9_tb));
+    
+    PWM_Driver DUTA( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty0_tb, period2_tb}), .signal(signalA_tb));
+    
+    PWM_Driver DUTB( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty1_tb, period2_tb}), .signal(signalB_tb));
+    
+    PWM_Driver DUTC( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty2_tb, period2_tb}), .signal(signalC_tb));
+    
+    PWM_Driver DUTD( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty3_tb, period2_tb}), .signal(signalD_tb));
+    
+    PWM_Driver DUTE( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty4_tb, period2_tb}), .signal(signalE_tb));
+    
+    PWM_Driver DUTF( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty0_tb, period3_tb}), .signal(signalF_tb));
+    
+    PWM_Driver DUT10( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty1_tb, period3_tb}), .signal(signal10_tb));
+    
+    PWM_Driver DUT11( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty2_tb, period3_tb}), .signal(signal11_tb));
+    
+    PWM_Driver DUT12( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty3_tb, period3_tb}), .signal(signal12_tb));
+    
+    PWM_Driver DUT13( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty4_tb, period3_tb}), .signal(signal13_tb));
+    
+    PWM_Driver DUT14( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty0_tb, period4_tb}), .signal(signal14_tb));
+        
+    PWM_Driver DUT15( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty1_tb, period4_tb}), .signal(signal15_tb));
+    
+    PWM_Driver DUT16( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty2_tb, period4_tb}), .signal(signal16_tb));
+       
+    PWM_Driver DUT17( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty3_tb, period4_tb}), .signal(signal17_tb));
+        
+    PWM_Driver DUT18( .sys_clk(clk_tb), .reset(rst_tb), .load(load_tb), .data({duty4_tb, period4_tb}), .signal(signal18_tb));        
+        
+    task CLOCK;
+        input [31:0] clk_count;
+        integer i;
+        begin
+            for (i=0; i<clk_count; i=i+1) begin
+                #1 clk_tb = 1;
+                #1 clk_tb = 0;
+            end
+        end
+    endtask
+
+    initial begin
+        duty0_tb = 8'd0;
+        duty1_tb = 8'd64;
+        duty2_tb = 8'd128;
+        duty3_tb = 8'd191;
+        duty4_tb = 8'd255;
+        period0_tb = 8'd0;
+        period1_tb = 8'd64;
+        period2_tb = 8'd128;
+        period3_tb = 8'd191;
+        period4_tb = 8'd255;
+        $display("PWM_Driver test start.\n");
+        #5 rst_tb = 1;
+        CLOCK(5);
+        #5 rst_tb = 0;
+        CLOCK(1);
+        #5 load_tb = 1;
+        CLOCK(5);
+        #5 load_tb = 0;
+        CLOCK(2);
+        #5;
+        CLOCK(MAX_CYCLE);
+
+        $display("PWM_Driver test complete.\n");
+        $finish;
+    end    
+endmodule

--- a/src/Peripherals/PWM_Driver.v
+++ b/src/Peripherals/PWM_Driver.v
@@ -1,0 +1,121 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company:  SJSU
+// Engineer: Colin Schardt
+// 
+// Create Date: 07/10/2018 07:06:16 PM
+// Design Name: 
+// Module Name: PWM_Driver
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module PWM_Driver #(
+    parameter INPUT_WIDTH = 8,
+    parameter DATA_WIDTH = 16
+    )(
+    input wire sys_clk,
+    input wire reset,
+    input wire load,
+    input wire [DATA_WIDTH  - 1:0] data,
+    output reg signal
+);
+// ==================================
+//// Internal Parameter Field
+// ==================================
+// ==================================
+//// Registers
+// ==================================
+reg [INPUT_WIDTH - 1:0] duty_counter;
+reg [INPUT_WIDTH - 1:0] duty_compare_value;
+// ==================================
+//// Wires
+// ==================================
+wire [INPUT_WIDTH - 1:0] duty;
+wire [INPUT_WIDTH - 1:0] period;
+wire pwm_clk;
+// ==================================
+//// Wire Assignments
+// ==================================
+assign period = data[7:0];
+assign duty = data[15:8];
+// ==================================
+//// Modules
+// ==================================
+VARIABLE_CLOCK_GENERATOR CLOCK1 (.DIVIDEND(period), .rst(reset), .fast_clk(sys_clk), .slow_clk(pwm_clk));
+// ==================================
+//// Behavioral Block
+// ==================================
+initial duty_counter <= 0;
+initial signal <= 0;
+initial duty_compare_value <=0;
+    
+always @(posedge pwm_clk or posedge reset or posedge load) begin
+// Reset values
+    if (reset) begin
+        duty_counter = 0;
+        signal = 0;
+        duty_compare_value = 0;
+    end
+// load values into internal registers
+    else if (load) begin                                 
+        duty_compare_value = duty;        
+    end
+    else begin
+// turn the signal on when counter resets
+        if (duty_counter >= 255) begin
+            signal = 1;
+            duty_counter = 0;
+        end
+// turn the signal off when counter passes duty cycle value
+        else if (duty_counter >= duty_compare_value)
+            signal = 0;
+        duty_counter = duty_counter + 1;
+    end
+end
+endmodule
+
+module VARIABLE_CLOCK_GENERATOR #(DIVISOR = 2)
+(
+    input wire [7:0] DIVIDEND,
+    input wire rst,
+    input wire fast_clk,
+    output reg slow_clk
+);
+
+reg [31:0] counter = 0;
+reg [8:0] DIV_REG;
+always @(posedge fast_clk or posedge rst)
+begin
+    if(rst)
+    begin
+        slow_clk <= 0;
+        counter <= 0;
+    end
+    else
+    begin
+        DIV_REG <= DIVIDEND + 2;
+        if(counter == DIV_REG/2)
+        begin
+            slow_clk <= ~slow_clk;
+            counter <= 0;
+        end
+        else
+        begin
+            slow_clk <= slow_clk;
+            counter <= counter + 1;
+        end
+    end
+end
+
+endmodule


### PR DESCRIPTION
PWM_Driver.v takes parallel input for frequency and duty cycle. By default, these are a 32 bit bus and a 8 bit bus, respectively. The module accepts frequency inputs up to 100 kHz and will automatically adjust to that frequency if a larger value is input. The module accepts duty cycle inputs as percentages of 255. For example: if the users desire a 50% duty cycle, they would need to input binary 128 for the closest approximation. In addition, the module has reset and load input signals. The reset signal clears the values the user has input, while load will load whichever values are currently present on the data inputs. The module's only output is a PWM signal with the desired frequency and duty cycle. 

Test_PWMDriver.v tests 16 concurrent instances of PWM_Driver.v for an arbitrary length of time. There are 4 devices tested at 25kHz, 50kHz, 75kHz, and 100 kHz each. At each frequency, the 4 devices are tested at 25%, 50%, 75%, and 100% duty cycles respectively. The simulation waveform allows for easy analysis of the resulting signals.